### PR TITLE
add close() for freeing up the event loop for program exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Unlocks a resource.
 
 Notice: unlock does not provide a callback, for unlocking attempts are best-effort, and there is no guarantee that the resource will be unlocked.
 
+### close()
+Disconnect from all redis-servers.
+
+This maybe useful for releasing the event loop for letting your program exit.
+Note that this effectively makes this multiredlock instance unusable.
+
 ## Tests
 This project has integration and failover tests implemented with Vagrant and Docker.
 The tests simulate a production environment where redis servers may crash.

--- a/index.js
+++ b/index.js
@@ -194,4 +194,10 @@ Redlock.prototype.unlock = function(resource, value) {
   });
 };
 
+Redlock.prototype.close = function() {
+  this.clients.forEach(function(client) {
+    client.quit();
+  });
+};
+
 module.exports = Redlock;

--- a/test/unit.js
+++ b/test/unit.js
@@ -167,4 +167,11 @@ describe('Redlock with three servers', function() {
       expect(clientStub.eval).to.have.been.calledThrice;
     });
   });
+
+  describe('#close()', function() {
+    it('should call redisClient.quit thrice', function() {
+      redlock.close();
+      expect(clientStub.quit).to.have.been.calledThrice;
+    });
+  });
 });


### PR DESCRIPTION
this pr adds a close() to quit the redis connections for letting a program exit.
